### PR TITLE
hotfix for textedit

### DIFF
--- a/src/modules/settings/settings-section.component.vue
+++ b/src/modules/settings/settings-section.component.vue
@@ -10,7 +10,9 @@
       </div>
 
     </h4>
-    <div v-for="setting in section.settings" v-if="isCollapsed" class="setting-section__settings single-setting u-mb4">
+    <div v-for="setting in section.settings"
+         :key="setting.id"
+         v-if="isCollapsed" class="setting-section__settings single-setting u-mb4">
       <ba-single-setting :setting="setting"></ba-single-setting>
     </div>
 

--- a/src/modules/settings/single-setting.component.vue
+++ b/src/modules/settings/single-setting.component.vue
@@ -124,6 +124,7 @@ export default {
 
       let payload = {
         setting: this.setting,
+        companyId: this.$route.params.companyId,
         newValue: value,
         oldValue: this.settingValueClone,
       }


### PR DESCRIPTION
pass  `companyId` to string settings also, not only for regular settings